### PR TITLE
Add Dockerfile for FastAPI service

### DIFF
--- a/FastAPI_app/Dockerfile
+++ b/FastAPI_app/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+# set work directory
+WORKDIR /app
+
+# install dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# copy application
+COPY . /app/FastAPI_app
+
+# specify environment variables
+ENV PYTHONPATH=/app
+
+# expose port
+EXPOSE 8000
+
+CMD ["uvicorn", "FastAPI_app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+


### PR DESCRIPTION
## Summary
- provide a Dockerfile in `FastAPI_app/` so that `docker compose build` works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684599505b90832a90f298c342bb85a5