### PR TITLE
Improve router docs and README instructions

### DIFF
--- a/FastAPI_app/routes/dataset.py
+++ b/FastAPI_app/routes/dataset.py
@@ -8,6 +8,30 @@ from bson.errors import InvalidId
 
 router = APIRouter()
 
+"""Dataset API routes.
+
+This module exposes CRUD endpoints for managing datasets and reference
+information stored in MongoDB. Each route is prefixed with ``/api`` when the
+router is included in the main application.
+
+Endpoints
+---------
+``POST   /dataset``
+    Create a new :class:`ReferenceData` document.
+
+``GET    /dataset``
+    Retrieve all stored reference data entries.
+
+``GET    /dataset/{object_id}``
+    Retrieve a specific reference data entry by MongoDB object id.
+
+``PUT    /dataset/{object_id}``
+    Replace an existing entry with new data.
+
+``DELETE /dataset/{object_id}``
+    Remove a reference data entry.
+"""
+
 @router.post("/dataset", response_model=dict)
 async def create_reference_data(reference_data: ReferenceData = Body(...)):
     try:

--- a/FastAPI_app/routes/encoding.py
+++ b/FastAPI_app/routes/encoding.py
@@ -10,6 +10,32 @@ from bson.errors import InvalidId
 
 router = APIRouter()
 
+"""Encoding API routes.
+
+These endpoints validate and store quantum circuit encodings. The router is
+mounted under ``/api`` in the main application.
+
+Endpoints
+---------
+``POST   /encode``
+    Send an encoding identifier to the worker via RabbitMQ.
+
+``POST   /encoding``
+    Validate a quantum circuit definition and store it if valid.
+
+``GET    /encoding``
+    List all stored encodings.
+
+``GET    /encoding/{object_id}``
+    Retrieve a single encoding entry.
+
+``PUT    /encoding/{object_id}``
+    Update an existing encoding after validation.
+
+``DELETE /encoding/{object_id}``
+    Delete an encoding entry.
+"""
+
 @router.post("/encode")
 def send_encoding_to_worker(encoding_id: int):
     try:

--- a/FastAPI_app/routes/result.py
+++ b/FastAPI_app/routes/result.py
@@ -9,6 +9,30 @@ from typing import Dict, List
 
 router = APIRouter()
 
+"""Benchmark result API routes.
+
+Endpoints manage the storage and retrieval of benchmark results produced by
+the worker process. The router is mounted under ``/api`` in the main
+application.
+
+Endpoints
+---------
+``POST   /result``
+    Store a new benchmark result document.
+
+``GET    /result``
+    Retrieve all benchmark results with associated encoding and ansatz info.
+
+``GET    /result/{object_id}``
+    Retrieve a specific benchmark result.
+
+``PUT    /result/{object_id}``
+    Update an existing benchmark result document.
+
+``DELETE /result/{object_id}``
+    Delete a benchmark result document.
+"""
+
 @router.post("/result", response_model=dict)
 async def create_benchmark_result(result: BenchmarkResult = Body(...)):
     try:

--- a/FastAPI_app/routes/run.py
+++ b/FastAPI_app/routes/run.py
@@ -9,6 +9,30 @@ from bson.errors import InvalidId
 
 router = APIRouter()
 
+"""Benchmark run API routes.
+
+These endpoints coordinate benchmark executions. Requests are stored in
+MongoDB and tasks are dispatched to the worker via RabbitMQ. The router is
+mounted under ``/api``.
+
+Endpoints
+---------
+``POST   /run``
+    Create a benchmark run request and send it to the worker.
+
+``GET    /run``
+    List all benchmark run requests.
+
+``GET    /run/{object_id}``
+    Retrieve a single benchmark run by id.
+
+``PUT    /run/{object_id}``
+    Update the parameters of an existing run request.
+
+``DELETE /run/{object_id}``
+    Delete a benchmark run entry.
+"""
+
 @router.post("/run", response_model=RunBenchmarkResponse)
 async def start_benchmark(request: RunBenchmarkRequest = Body(...)):
     try:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,29 @@ This software project focuses on addressing that challenge by developing a dedic
 
 ## Installation
 
+### Start backend services
+The project provides a Docker setup for running the FastAPI server,
+MongoDB and RabbitMQ. From the repository root simply execute:
+
+```bash
+docker-compose up
+```
+
+If you need to rebuild the Docker images, use:
+
+```bash
+docker-compose up --build
+```
+
+This will start all three services and expose the FastAPI application on
+`http://localhost:8000`.
+
+### Using the Swagger UI
+FastAPI provides interactive API documentation via Swagger UI. Once the services
+are running, open your browser and navigate to `http://localhost:8000/docs` to
+view and test the available endpoints. An alternative ReDoc interface is
+available at `http://localhost:8000/redoc`.
+
 ## Usage
 Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples if they are too long to reasonably include in the README.
 


### PR DESCRIPTION
## Summary
- document dataset API routes
- document encoding API routes
- document result API routes
- document run API routes
- describe how to start the backend services with Docker
- add instructions for using Swagger UI

## Testing
- `python run_api_tests.py` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_684fd52a5cac832a84b280a196979f43