### PR TITLE
Add example payloads for all APIs and test script

### DIFF
--- a/FastAPI_app/examples/dataset/invalid_dataset.json
+++ b/FastAPI_app/examples/dataset/invalid_dataset.json
@@ -1,0 +1,4 @@
+{
+  "encodings": {},
+  "ansaetze": {}
+}

--- a/FastAPI_app/examples/dataset/valid_dataset1.json
+++ b/FastAPI_app/examples/dataset/valid_dataset1.json
@@ -1,0 +1,25 @@
+{
+  "encodings": {
+    "1": {
+      "depth": 2,
+      "name": "Encoding 1",
+      "description": "Simple encoding example",
+      "circuit": {"gates": []}
+    }
+  },
+  "ansaetze": {
+    "1": {
+      "depth": 3,
+      "name": "Ansatz 1",
+      "description": "Basic ansatz",
+      "circuit": {"gates": []}
+    }
+  },
+  "data": {
+    "1": {
+      "depth": 1,
+      "name": "Dataset 1",
+      "description": "Example dataset"
+    }
+  }
+}

--- a/FastAPI_app/examples/dataset/valid_dataset2.json
+++ b/FastAPI_app/examples/dataset/valid_dataset2.json
@@ -1,0 +1,25 @@
+{
+  "encodings": {
+    "2": {
+      "depth": 1,
+      "name": "Encoding 2",
+      "description": "Another encoding",
+      "circuit": {"gates": [{"type": "H", "target": [0]}]}
+    }
+  },
+  "ansaetze": {
+    "2": {
+      "depth": 2,
+      "name": "Ansatz 2",
+      "description": "Second ansatz",
+      "circuit": {"gates": [{"type": "RX", "target": [0], "params": ["x"]}]}
+    }
+  },
+  "data": {
+    "2": {
+      "depth": 1,
+      "name": "Dataset 2",
+      "description": "Second dataset"
+    }
+  }
+}

--- a/FastAPI_app/examples/dataset/valid_dataset3.json
+++ b/FastAPI_app/examples/dataset/valid_dataset3.json
@@ -1,0 +1,25 @@
+{
+  "encodings": {
+    "3": {
+      "depth": 4,
+      "name": "Encoding 3",
+      "description": "Third encoding",
+      "circuit": {"gates": [{"type": "RZ", "target": [1], "params": ["z"]}]}
+    }
+  },
+  "ansaetze": {
+    "3": {
+      "depth": 1,
+      "name": "Ansatz 3",
+      "description": "Third ansatz",
+      "circuit": {"gates": []}
+    }
+  },
+  "data": {
+    "3": {
+      "depth": 1,
+      "name": "Dataset 3",
+      "description": "Third dataset"
+    }
+  }
+}

--- a/FastAPI_app/examples/result/invalid_result.json
+++ b/FastAPI_app/examples/result/invalid_result.json
@@ -1,0 +1,6 @@
+{
+  "encoding_id": 1,
+  "ansatz_id": 1,
+  "data_id": 1,
+  "loss": "none"
+}

--- a/FastAPI_app/examples/result/valid_result1.json
+++ b/FastAPI_app/examples/result/valid_result1.json
@@ -1,0 +1,7 @@
+{
+  "encoding_id": 1,
+  "ansatz_id": 1,
+  "data_id": 1,
+  "loss": 0.25,
+  "accuracy": 0.9
+}

--- a/FastAPI_app/examples/result/valid_result2.json
+++ b/FastAPI_app/examples/result/valid_result2.json
@@ -1,0 +1,7 @@
+{
+  "encoding_id": 2,
+  "ansatz_id": 2,
+  "data_id": 2,
+  "loss": 0.15,
+  "accuracy": 0.95
+}

--- a/FastAPI_app/examples/result/valid_result3.json
+++ b/FastAPI_app/examples/result/valid_result3.json
@@ -1,0 +1,7 @@
+{
+  "encoding_id": 3,
+  "ansatz_id": 1,
+  "data_id": 2,
+  "loss": 0.4,
+  "accuracy": 0.85
+}

--- a/FastAPI_app/examples/run/invalid_run.json
+++ b/FastAPI_app/examples/run/invalid_run.json
@@ -1,0 +1,4 @@
+{
+  "encoding_id": "one",
+  "ansatz_id": 1
+}

--- a/FastAPI_app/examples/run/valid_run1.json
+++ b/FastAPI_app/examples/run/valid_run1.json
@@ -1,0 +1,5 @@
+{
+  "encoding_id": 1,
+  "ansatz_id": 1,
+  "data_id": 1
+}

--- a/FastAPI_app/examples/run/valid_run2.json
+++ b/FastAPI_app/examples/run/valid_run2.json
@@ -1,0 +1,5 @@
+{
+  "encoding_id": 2,
+  "ansatz_id": 2,
+  "data_id": 2
+}

--- a/FastAPI_app/examples/run/valid_run3.json
+++ b/FastAPI_app/examples/run/valid_run3.json
@@ -1,0 +1,5 @@
+{
+  "encoding_id": 3,
+  "ansatz_id": 1,
+  "data_id": 2
+}

--- a/run_api_tests.py
+++ b/run_api_tests.py
@@ -4,11 +4,15 @@ import time
 import requests
 
 BASE_URL = os.getenv("API_URL", "http://localhost:8000/api")
-EXAMPLE_DIR = os.path.join("FastAPI_app", "quantum_validator", "example")
+
+ENCODING_EXAMPLE_DIR = os.path.join("FastAPI_app", "quantum_validator", "example")
+DATASET_EXAMPLE_DIR = os.path.join("FastAPI_app", "examples", "dataset")
+RUN_EXAMPLE_DIR = os.path.join("FastAPI_app", "examples", "run")
+RESULT_EXAMPLE_DIR = os.path.join("FastAPI_app", "examples", "result")
 
 
-def load_example(name):
-    path = os.path.join(EXAMPLE_DIR, name)
+def load_example(directory, name):
+    path = os.path.join(directory, name)
     with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
 
@@ -33,6 +37,36 @@ def test_post_encoding(data, name):
     return result, resp
 
 
+def test_post_dataset(data, name):
+    resp = requests.post(f"{BASE_URL}/dataset", json=data)
+    try:
+        result = resp.json()
+    except Exception:
+        result = resp.text
+    pretty_print(f"POST /dataset [{name}]", resp.status_code, result)
+    return result, resp
+
+
+def test_post_run(data, name):
+    resp = requests.post(f"{BASE_URL}/run", json=data)
+    try:
+        result = resp.json()
+    except Exception:
+        result = resp.text
+    pretty_print(f"POST /run [{name}]", resp.status_code, result)
+    return result, resp
+
+
+def test_post_result(data, name):
+    resp = requests.post(f"{BASE_URL}/result", json=data)
+    try:
+        result = resp.json()
+    except Exception:
+        result = resp.text
+    pretty_print(f"POST /result [{name}]", resp.status_code, result)
+    return result, resp
+
+
 def test_send_to_worker(encoding_id):
     resp = requests.post(f"{BASE_URL}/encode", params={"encoding_id": encoding_id})
     pretty_print(f"POST /encode?encoding_id={encoding_id}", resp.status_code, resp.text)
@@ -48,16 +82,50 @@ def list_encodings():
     return data
 
 
+def list_datasets():
+    resp = requests.get(f"{BASE_URL}/dataset")
+    try:
+        data = resp.json()
+    except Exception:
+        data = resp.text
+    pretty_print("GET /dataset", resp.status_code, data)
+    return data
+
+
+def list_runs():
+    resp = requests.get(f"{BASE_URL}/run")
+    try:
+        data = resp.json()
+    except Exception:
+        data = resp.text
+    pretty_print("GET /run", resp.status_code, data)
+    return data
+
+
+def list_results():
+    resp = requests.get(f"{BASE_URL}/result")
+    try:
+        data = resp.json()
+    except Exception:
+        data = resp.text
+    pretty_print("GET /result", resp.status_code, data)
+    return data
+
+
+def int_to_object_id(value: int) -> str:
+    return hex(value)[2:].rjust(24, "0")
+
+
 def run_tests():
     print("========== Running API Tests ==========")
 
     print("\n🟢 Testing valid circuits...")
     for name in ["valid_circuit1.json", "valid_circuit2.json", "valid_circuit3.json"]:
-        data = load_example(name)
+        data = load_example(ENCODING_EXAMPLE_DIR, name)
         test_post_encoding(data, name)
 
     print("\n🔴 Testing invalid circuit...")
-    invalid = load_example("invalid_circuit.json")
+    invalid = load_example(ENCODING_EXAMPLE_DIR, "invalid_circuit.json")
     test_post_encoding(invalid, "invalid_circuit.json")
 
     print("\n📋 Listing encodings...")
@@ -73,7 +141,9 @@ def run_tests():
             pretty_print(f"GET /encoding/{obj_id}", resp.status_code, resp.text)
 
             # PUT (send same data again)
-            resp = requests.put(f"{BASE_URL}/encoding/{obj_id}", json=encodings[0]["circuit"])
+            resp = requests.put(
+                f"{BASE_URL}/encoding/{obj_id}", json=encodings[0]["circuit"]
+            )
             pretty_print(f"PUT /encoding/{obj_id}", resp.status_code, resp.text)
 
             # DELETE
@@ -84,12 +154,79 @@ def run_tests():
     test_send_to_worker(1)
     test_send_to_worker("invalid")
 
+    # ==== Dataset API ====
+    dataset_ids = []
+    print("\n🟢 Testing valid reference data...")
+    for name in ["valid_dataset1.json", "valid_dataset2.json", "valid_dataset3.json"]:
+        data = load_example(DATASET_EXAMPLE_DIR, name)
+        result, resp = test_post_dataset(data, name)
+        if isinstance(result, dict) and "id" in result:
+            dataset_ids.append(result["id"])
+
+    print("\n🔴 Testing invalid reference data...")
+    invalid_dataset = load_example(DATASET_EXAMPLE_DIR, "invalid_dataset.json")
+    test_post_dataset(invalid_dataset, "invalid_dataset.json")
+
+    print("\n📋 Listing datasets...")
+    list_datasets()
+
+    # ==== Run API ====
+    run_ids = []
+    print("\n🟢 Testing valid run requests...")
+    for name in ["valid_run1.json", "valid_run2.json", "valid_run3.json"]:
+        data = load_example(RUN_EXAMPLE_DIR, name)
+        result, resp = test_post_run(data, name)
+        if isinstance(result, dict) and "id" in result:
+            try:
+                run_ids.append(int_to_object_id(int(result["id"])))
+            except Exception:
+                pass
+
+    print("\n🔴 Testing invalid run request...")
+    invalid_run = load_example(RUN_EXAMPLE_DIR, "invalid_run.json")
+    test_post_run(invalid_run, "invalid_run.json")
+
+    print("\n📋 Listing runs...")
+    list_runs()
+
+    # ==== Result API ====
+    result_ids = []
+    print("\n🟢 Testing valid benchmark results...")
+    for name in ["valid_result1.json", "valid_result2.json", "valid_result3.json"]:
+        data = load_example(RESULT_EXAMPLE_DIR, name)
+        result, resp = test_post_result(data, name)
+        if isinstance(result, dict) and "id" in result:
+            result_ids.append(result["id"])
+
+    print("\n🔴 Testing invalid benchmark result...")
+    invalid_res = load_example(RESULT_EXAMPLE_DIR, "invalid_result.json")
+    test_post_result(invalid_res, "invalid_result.json")
+
+    print("\n📋 Listing results...")
+    list_results()
+
+    # ==== Cleanup ====
     print("\n🧹 Cleaning up: deleting all encodings...")
     for item in encodings:
         obj_id = item.get("_id")
         if obj_id:
             resp = requests.delete(f"{BASE_URL}/encoding/{obj_id}")
             print(f"  - Deleted {obj_id} -> status {resp.status_code}")
+
+    print("🧹 Cleaning up: deleting all datasets...")
+    for did in dataset_ids:
+        resp = requests.delete(f"{BASE_URL}/dataset/{did}")
+        print(f"  - Deleted {did} -> status {resp.status_code}")
+
+    print("🧹 Cleaning up: deleting all runs...")
+    for rid in run_ids:
+        resp = requests.delete(f"{BASE_URL}/run/{rid}")
+        print(f"  - Deleted {rid} -> status {resp.status_code}")
+
+    print("🧹 Cleaning up: deleting all results...")
+    for rid in result_ids:
+        resp = requests.delete(f"{BASE_URL}/result/{rid}")
+        print(f"  - Deleted {rid} -> status {resp.status_code}")
 
     print("\n✅ All tests completed.\n")
 


### PR DESCRIPTION
## Summary
- add example request payloads for dataset, run and result APIs
- extend `run_api_tests.py` to test dataset, run and result endpoints in addition to encodings

## Testing
- `python -m py_compile run_api_tests.py`
- `pip install requests`
- `python run_api_tests.py` *(fails: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684fddfac2b0832a936c3cd5e80f6a70